### PR TITLE
Fix error page header typo

### DIFF
--- a/patipati/error.html
+++ b/patipati/error.html
@@ -23,12 +23,12 @@ a:hover {
   <br>
   <table width="450" border="0" cellspacing="1" cellpadding="5" bgcolor="#999999">
     <tr> 
-      <td bgcolor="#efefef">ERROR�F</td>
+      <td bgcolor="#efefef">ERROR</td>
     </tr>
     <tr> 
       <td bgcolor="#f9f9f9"> 
         <!--error-->
-<br><br>�ēx���e����ꍇ�A�u���E�U�̢�߂飂��g���Ă��������B
+<br><br>再度投稿する場合、ブラウザの｢戻る｣を使ってください。
       </td>
     </tr>
   </table>  


### PR DESCRIPTION
## Summary
- correct typo in `error.html` page header

## Testing
- `grep -n ERROR patipati/error.html | head`

------
https://chatgpt.com/codex/tasks/task_e_684233608f0083229bc18902edd79d81