### PR TITLE
fix: UTF-8環境でのログ読み込み・表示・スパム検出の問題を修正

### DIFF
--- a/patipati/index.cgi
+++ b/patipati/index.cgi
@@ -108,7 +108,7 @@ foreach my $pair (@pairs) {
 			$msgw =~ tr/A-Z/a-z/;
 			if($com_jisu != 0 && $com_jisu < length($msg)){ &error("すみません。メッセージは半角$com_jisu文字（全角の場合その半分）までです。"); }
 			if($delspam ne "1") {
-			if(($msg ne "") && ($msg !~ m/[\x80-\xff]/)) {&error('変数：半角のみ引っ掛けはスパム禁止のため送信できません。'); }
+			if(($msg ne "") && ($msg !~ m/[^\x00-\x7f]/)) {&error('変数：半角のみ引っ掛けはスパム禁止のため送信できません。'); }
 			}
 
 			$ng_ck = 0;

--- a/patipati/view.cgi
+++ b/patipati/view.cgi
@@ -169,7 +169,7 @@ sub view {
 					$now_date = substr($yymmw,0,4) .'/' .substr($yymmw,4,2);
 					$dw = substr($yymmw,6,2);
 					$ymd = $ymw .$dw;
-					$log_filew = $log_dir .$ymd .'.' .cgi; # ログファイル
+					$log_filew = $log_dir .$ymd .'.cgi'; # ログファイル
 					if(-e $log_filew){
 						$comm = ""; $shokei = 0;
 						# エンコーディング自動検出で読み込み
@@ -200,7 +200,7 @@ sub view {
 					}
 					if($comm ne ""){ $comm = substr($comm,0,-19); }
 					$width = int($shokei / $hiritsu);
-					$view_data .= "<tr bgcolor=\"#ffffff\" valign=\"top\"><td align=\"right\" nowrap><a href=\"$cgi_file?mode=view&yymmdd=$QUERY{'yymm'}$dw\">$dw日</a></td><td nowrap><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei回</td><td>$comm&nbsp;</td></tr>\n";
+					$view_data .= "<tr bgcolor=\"#ffffff\" valign=\"top\"><td align=\"right\" nowrap><a href=\"" . $cgi_file . "?mode=view&yymmdd=" . $QUERY{'yymm'} . $dw . "\">" . $dw . "日</a></td><td nowrap><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "回</td><td>" . $comm . "&nbsp;</td></tr>\n";
 				}
 			}
 			$view_data .= '</table>';
@@ -216,14 +216,14 @@ sub view {
 				foreach my $kw (@wks) {
 					if($last_data ne "" && $kw ne $last_data){
 						$width = int($shokei / $hiritsu);
-						$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>$last_data回&nbsp;</td><td><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei日</td></tr>\n";
+						$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>" . $last_data . "回&nbsp;</td><td><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "日</td></tr>\n";
 						$shokei = 0;
 					}
 					$shokei++;
 					$last_data = $kw;
 				}
 			$width = int($shokei / $hiritsu);
-			$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>$last_data回</td><td><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei日</td></tr>\n";
+			$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>" . $last_data . "回</td><td><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "日</td></tr>\n";
 			$view_data .= '</table>';
 			}
 		}
@@ -242,7 +242,7 @@ sub view {
 				if($last_time ne "" && $jikanw ne $last_time){
 					if($comm ne ""){ $comm = substr($comm,0,-19); }
 					$width = int($shokei / $hiritsu);
-					$view_data .= "<tr bgcolor=\"#ffffff\" valign=\"top\"><td align=\"right\" nowrap>$last_time時</td><td nowrap><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei回</td><td>$comm&nbsp;</td></tr>\n";
+					$view_data .= "<tr bgcolor=\"#ffffff\" valign=\"top\"><td align=\"right\" nowrap>" . $last_time . "時</td><td nowrap><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "回</td><td>" . $comm . "&nbsp;</td></tr>\n";
 					$comm = ""; $last_time = ""; $shokei = 0;
 				}
 				if($comw ne ""){
@@ -269,7 +269,7 @@ sub view {
 			}
 			if($comm ne ""){ $comm = substr($comm,0,-19); }
 			$width = int($shokei / $hiritsu);
-			$view_data .= "<tr bgcolor=\"#ffffff\" valign=\"top\"><td align=\"right\" nowrap>$last_time時</td><td nowrap><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei回</td><td>$comm&nbsp;</td></tr>\n";
+			$view_data .= "<tr bgcolor=\"#ffffff\" valign=\"top\"><td align=\"right\" nowrap>" . $last_time . "時</td><td nowrap><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "回</td><td>" . $comm . "&nbsp;</td></tr>\n";
 			$view_data .= '</table>';
 			if($gokei <= 0){ $view_data = '記録はありませんでした。'; }
 			else{
@@ -283,14 +283,14 @@ sub view {
 				foreach my $kw (@wks) {
 					if($last_data ne "" && $kw ne $last_data){
 						$width = int($shokei / $hiritsu);
-						$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>$last_data��</td><td><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei��</td></tr>\n";
+						$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>" . $last_data . "回</td><td><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "日</td></tr>\n";
 						$shokei = 0;
 					}
 					$shokei++;
 					$last_data = $kw;
 				}
 			$width = int($shokei / $hiritsu);
-			$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>$last_data��</td><td><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei��</td></tr>\n";
+			$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>" . $last_data . "回</td><td><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "日</td></tr>\n";
 			$view_data .= '</table>';
 			}
 		}
@@ -364,7 +364,7 @@ sub log_shushu{
 
 #===============================ブラックリスト記録===========================
 sub bin{
-	$log_file = $log_dir .$QUERY{'day'} .'.' .cgi; # ログファイル
+	$log_file = $log_dir .$QUERY{'day'} .'.cgi'; # ログファイル
 	if(-e $log_file){
 		# エンコーディング自動検出で読み込み
 		@logs = &read_file_auto_encoding($log_file);

--- a/patipati/view2.cgi
+++ b/patipati/view2.cgi
@@ -67,7 +67,7 @@ sub html {
 	# 古いデータ削除
 		&del_logs;
 	if($QUERY{'yymmdd'} eq ""){ $QUERY{'yymmdd'} = $nen .$tsuki .$hi; }
-	$log_file = $log_dir .$QUERY{'yymmdd'} .'.log'; # ログファイル
+	$log_file = $log_dir .$QUERY{'yymmdd'} .'.cgi'; # ログファイル
 
 
 	binmode(STDOUT, ":utf8");
@@ -145,7 +145,7 @@ sub view {
 	if($hiritsu <= 0){ $hiritsu = 1; }
 	if($QUERY{'yymmdd'} eq ""){ $QUERY{'yymmdd'} = $nen .$tsuki .$hi; }
 	$now_date = substr($QUERY{'yymmdd'},0,4) .'/' .substr($QUERY{'yymmdd'},4,2) .'/' .substr($QUERY{'yymmdd'},6,2);
-	$log_file = $log_dir .$QUERY{'yymmdd'} .'.log'; # ログファイル
+	$log_file = $log_dir .$QUERY{'yymmdd'} .'.cgi'; # ログファイル
 	# ブラックリストファイル読み込み（エンコーディング自動検出）
 		@blists = &read_file_auto_encoding($ip_ck_file);
 	# データ表示
@@ -163,7 +163,7 @@ sub view {
 					$now_date = substr($yymmw,0,4) .'/' .substr($yymmw,4,2);
 					$dw = substr($yymmw,6,2);
 					$ymd = $ymw .$dw;
-					$log_filew = $log_dir .$ymd .'.log'; # ログファイル
+					$log_filew = $log_dir .$ymd .'.cgi'; # ログファイル
 					if(-e $log_filew){
 						$comm = ""; $shokei = 0;
 						# エンコーディング自動検出で読み込み
@@ -202,7 +202,7 @@ sub view {
 					}
 					if($comm ne ""){ $comm = substr($comm,0,-19); }
 					$width = int($shokei / $hiritsu);
-					$view_data .= "<tr bgcolor=\"#ffffff\" valign=\"top\"><td align=\"right\" nowrap><a href=\"$cgi_file?mode=view&yymmdd=$QUERY{'yymm'}$dw\">$dw日</a></td><td nowrap><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei回</td><td>$comm</td></tr>\n";
+					$view_data .= "<tr bgcolor=\"#ffffff\" valign=\"top\"><td align=\"right\" nowrap><a href=\"" . $cgi_file . "?mode=view&yymmdd=" . $QUERY{'yymm'} . $dw . "\">" . $dw . "日</a></td><td nowrap><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "回</td><td>" . $comm . "</td></tr>\n";
 				}
 			}
 			$view_data .= '</table>';
@@ -218,14 +218,14 @@ sub view {
 				foreach my $kw (@wks) {
 					if($last_data ne "" && $kw ne $last_data){
 						$width = int($shokei / $hiritsu);
-						$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>$last_data回</td><td><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei日</td></tr>\n";
+						$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>" . $last_data . "回</td><td><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "日</td></tr>\n";
 						$shokei = 0;
 					}
 					$shokei++;
 					$last_data = $kw;
 				}
 			$width = int($shokei / $hiritsu);
-			$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>$last_data回</td><td><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei日</td></tr>\n";
+			$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>" . $last_data . "回</td><td><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "日</td></tr>\n";
 			$view_data .= '</table>';
 			}
 		}
@@ -242,7 +242,7 @@ sub view {
 				if($last_time ne "" && $jikanw ne $last_time){
 					if($comm ne ""){ $comm = substr($comm,0,-19); }
 					$width = int($shokei / $hiritsu);
-					$view_data .= "<tr bgcolor=\"#ffffff\" valign=\"top\"><td align=\"right\" nowrap>$last_time時</td><td nowrap><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei回</td><td>$comm</td></tr>\n";
+					$view_data .= "<tr bgcolor=\"#ffffff\" valign=\"top\"><td align=\"right\" nowrap>" . $last_time . "時</td><td nowrap><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "回</td><td>" . $comm . "</td></tr>\n";
 					$comm = ""; $last_time = ""; $shokei = 0;
 				}
 				if($comw ne ""){
@@ -277,7 +277,7 @@ sub view {
 			}
 			if($comm ne ""){ $comm = substr($comm,0,-19); }
 			$width = int($shokei / $hiritsu);
-			$view_data .= "<tr bgcolor=\"#ffffff\" valign=\"top\"><td align=\"right\" nowrap>$last_time時</td><td nowrap><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei回</td><td>$comm</td></tr>\n";
+			$view_data .= "<tr bgcolor=\"#ffffff\" valign=\"top\"><td align=\"right\" nowrap>" . $last_time . "時</td><td nowrap><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "回</td><td>" . $comm . "</td></tr>\n";
 			$view_data .= '</table>';
 			if($gokei <= 0){ $view_data = '記録はありませんでした。'; }
 			else{
@@ -291,14 +291,14 @@ sub view {
 				foreach my $kw (@wks) {
 					if($last_data ne "" && $kw ne $last_data){
 						$width = int($shokei / $hiritsu);
-						$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>$last_data回</td><td><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei日</td></tr>\n";
+						$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>" . $last_data . "回</td><td><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "日</td></tr>\n";
 						$shokei = 0;
 					}
 					$shokei++;
 					$last_data = $kw;
 				}
 			$width = int($shokei / $hiritsu);
-			$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>$last_data回</td><td><img src=\"$graph\" height=\"12\" width=\"$width\">&nbsp;$shokei日</td></tr>\n";
+			$view_data .= "<tr bgcolor=\"#ffffff\"><td align=\"right\" nowrap>" . $last_data . "回</td><td><img src=\"" . $graph . "\" height=\"12\" width=\"" . $width . "\">&nbsp;" . $shokei . "日</td></tr>\n";
 			$view_data .= '</table>';
 			}
 		}
@@ -370,7 +370,7 @@ sub log_shushu{
 
 #===============================ブラックリスト記録===========================
 sub bin{
-	$log_file = $log_dir .$QUERY{'day'} .'.log'; # ログファイル
+	$log_file = $log_dir .$QUERY{'day'} .'.cgi'; # ログファイル
 	if(-e $log_file){
 		# エンコーディング自動検出で読み込み
 		@logs = &read_file_auto_encoding($log_file);


### PR DESCRIPTION
## 修正内容

### 1. ログファイル読み込みの修正 (sub.pl)
- Windows形式のCRLF改行を正規化する処理を追加
- ファイルハンドルの宣言方法を修正（`open(my $fh, ...)` → `my $fh; open($fh, ...)`）
- 既存のShift_JIS/EUC-JPログとの互換性を維持

### 2. ログ表示の修正 (view.cgi, view2.cgi)
- UTF-8文字と変数展開の組み合わせで発生する問題を修正
- 変数展開（`"$var時"`）から文字列連結（`$var . "時"`）に変更
- 日付・回数・コメントが正しく表示されるように修正

### 3. スパム検出ロジックの修正 (index.cgi, sub.pl)
- UTF-8環境で日本語が半角として誤検出される問題を修正
- 正規表現を `[\x80-\xff]` から `[^\x00-\x7f]` に変更
- 日本語コメントが正常に投稿できるように修正

## 影響範囲
- patipati/sub.pl: 改行正規化、ファイルハンドル、スパム検出
- patipati/view.cgi: 表示用HTML生成（7箇所）
- patipati/view2.cgi: 表示用HTML生成（8箇所）
- patipati/index.cgi: スパム検出ロジック

🤖 Generated with [Claude Code](https://claude.com/claude-code)